### PR TITLE
register postgres drivers with unique names

### DIFF
--- a/cloudsql_test.go
+++ b/cloudsql_test.go
@@ -3,6 +3,7 @@ package cloudsql
 import (
 	"database/sql"
 	"reflect"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -34,11 +35,11 @@ func TestNewDelegatesToVaultPostgresPlugin(t *testing.T) {
 	// assert that the driver was registered correctly
 	foundDriver := false
 	for _, v := range sql.Drivers() {
-		if v == Postgres.String() {
+		if strings.HasPrefix(v, "postgres-") {
 			foundDriver = true
 		}
 	}
 	if !foundDriver {
-		t.Error("expected the driver 'cloudsql-postgres' to be registered but was not found")
+		t.Error("expected a driver prefixed with 'postgres-' to be registered but was not found")
 	}
 }

--- a/cmd/vault-plugin-database-cloudsql/serve_test.go
+++ b/cmd/vault-plugin-database-cloudsql/serve_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/expel-io/vault-plugin-database-cloudsql/cloudsql"
 	"github.com/hashicorp/go-plugin"
 )
 
@@ -29,7 +29,7 @@ func TestServe(t *testing.T) {
 	// assert that the driver was registered correctly
 	foundDriver := false
 	for _, v := range sql.Drivers() {
-		if v == cloudsql.Postgres.String() {
+		if strings.HasPrefix(v, "postgres-") {
 			foundDriver = true
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/expel-io/vault-plugin-database-cloudsql/cloudsql v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-plugin v1.5.2
+	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/vault v1.10.3
 	github.com/hashicorp/vault/api v1.9.1
 	github.com/hashicorp/vault/sdk v0.10.2
@@ -47,7 +48,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/plugincontainer v0.2.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect


### PR DESCRIPTION
in order to support plugin multiplexing, ensure that drivers are registered with a unique name.